### PR TITLE
setting future to default as false

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -9,11 +9,7 @@ module.exports = {
     self.addFilter('future', {
       def: false,
       finalize: function() {
-        var future = self.get('future');
-        if (future === null) {
-          return;
-        }
-
+        var future = self.get('future') ? self.get('future') : false;
         var now = moment().format('YYYY-MM-DD');
 
         if (future) {


### PR DESCRIPTION
This will set the future variable to false. I don't see any recourse. 
It helps reduce required request variables when using this module in combination with apostrophe-headless and this module.

If this does cause an unforeseen issue, I have yet to encounter it.  

Without this change requests to the api require a future param:
`/api/v1/apostrophe-blog?future=false/true`

With this change, the base url will return blog articles not in the future with:
`/api/v1/apostrophe-blog`

