### PR TITLE
Add 'published At' to an arranged field

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
 
     options.arrangeFields = _.merge([
       { name: 'basic', label: 'Basics', fields: ['title', 'slug'] },
-      { name: 'meta', label: 'Meta', fields: ['tags','published'] }
+      { name: 'meta', label: 'Meta', fields: ['tags','published', 'publishedAt'] }
     ], options.arrangeFields || []);
 
     options.addColumns = [


### PR DESCRIPTION
Terminal keeps displaying:

doc type apostrophe-blog contains unarranged field(s): publishedAt.
Arrange all of your fields with arrangeFields, using meaningful group labels.
https://apos.dev/arrange-fields