### PR TITLE
Removes a broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+Fixes a broken link in the README.
+
 ### 2.2.1
 
 Arrange the `publishedAt` field, quashing spurious warnings. Thanks to Brad Wood.

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ The latter approach is often best as it requires less user training to avoid con
 
 The index page includes filters for `day`, `month`, and `year`, meaning that parameters in query strings like `&year=2016` will automatically be passed to the mongo query that loads the pieces for your index page. You can refer to these filters in your template by using `data.piecesFilters.year`, etc.
 
-[Check out this tutorial to learn more.](http://apostrophecms.org/docs/tutorials/intermediate/cursors.html#creating-filter-u-i-with-code-apostrophe-pieces-pages-code)
+[Check out this tutorial to learn more.](https://v2.docs.apostrophecms.org/core-concepts/reusable-content-pieces/joins.html#filtering-the-list-of-people)

--- a/README.md
+++ b/README.md
@@ -69,3 +69,5 @@ The latter approach is often best as it requires less user training to avoid con
 ## Filtering blog posts
 
 The index page includes filters for `day`, `month`, and `year`, meaning that parameters in query strings like `&year=2016` will automatically be passed to the mongo query that loads the pieces for your index page. You can refer to these filters in your template by using `data.piecesFilters.year`, etc.
+
+[Check out this tutorial to learn more.](http://apostrophecms.org/docs/tutorials/intermediate/cursors.html#creating-filter-u-i-with-code-apostrophe-pieces-pages-code)

--- a/README.md
+++ b/README.md
@@ -69,5 +69,3 @@ The latter approach is often best as it requires less user training to avoid con
 ## Filtering blog posts
 
 The index page includes filters for `day`, `month`, and `year`, meaning that parameters in query strings like `&year=2016` will automatically be passed to the mongo query that loads the pieces for your index page. You can refer to these filters in your template by using `data.piecesFilters.year`, etc.
-
-[Check out this tutorial to learn more.](http://apostrophecms.org/docs/tutorials/intermediate/cursors.html#creating-filter-u-i-with-code-apostrophe-pieces-pages-code)


### PR DESCRIPTION
It isn't clear where that link was going. There doesn't seem to be anything in the A2 docs that seems to match the URL.